### PR TITLE
Add basic FastAPI structure

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from routers import gpt_bot
+
+app = FastAPI()
+
+app.mount("/static", StaticFiles(directory="static"), name="static")
+
+templates = Jinja2Templates(directory="templates")
+
+app.include_router(gpt_bot.router, prefix="/api")
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True)

--- a/routers/gpt_bot.py
+++ b/routers/gpt_bot.py
@@ -1,0 +1,9 @@
+from fastapi import APIRouter, UploadFile, File
+
+router = APIRouter()
+
+@router.post("/gpt-bot")
+async def gpt_bot(file: UploadFile = File(...)):
+    data = await file.read()
+    # Here you would send `data` to OpenAI's API and return the response
+    return {"message": f"Received {len(data)} bytes"}

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,35 @@
+let mediaRecorder;
+let chunks = [];
+
+const recordBtn = document.getElementById('record');
+
+recordBtn.addEventListener('click', async () => {
+    if (!mediaRecorder || mediaRecorder.state === 'inactive') {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        mediaRecorder = new MediaRecorder(stream);
+        mediaRecorder.ondataavailable = e => chunks.push(e.data);
+        mediaRecorder.onstop = sendAudio;
+        mediaRecorder.start();
+        recordBtn.textContent = 'Stop recording';
+    } else {
+        mediaRecorder.stop();
+        recordBtn.textContent = 'Start recording';
+    }
+});
+
+function sendAudio() {
+    const blob = new Blob(chunks, { type: 'audio/webm' });
+    chunks = [];
+    const formData = new FormData();
+    formData.append('file', blob, 'recording.webm');
+
+    fetch('/api/gpt-bot', {
+        method: 'POST',
+        body: formData
+    })
+    .then(res => res.json())
+    .then(data => {
+        console.log(data);
+    })
+    .catch(err => console.error(err));
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>GPT Voice Bot</title>
+</head>
+<body>
+    <h1>GPT Voice Bot</h1>
+    <button id="record">Start recording</button>
+    <script src="/static/script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add main server app using FastAPI
- create GPT router stub
- add simple HTML interface
- add JS for recording audio and sending to API

## Testing
- `python -m py_compile main.py routers/gpt_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_684bfe44ab1c8320922ff3b32f104cae